### PR TITLE
Fix link to blog post in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Polynote, A better notebook for Scala
 
-This repository groups all the resources necessary to follow this [blog post](vincentbrule.com/2020-07-21-polynote/).
+This repository groups all the resources necessary to follow this [blog post](https://blog.lunatech.com/2020/09/polynote-a-better-notebook-to-scala/).
 You can find the **slides** and the necessary Notebooks.
 
 ## Prerequisite


### PR DESCRIPTION
Just stumbled on a broken link to blog post via the corresponding Lunatech blog post that link to these examples.